### PR TITLE
Disable Vue extractors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "storybook-zeplin",
-    "version": "1.7.13",
+    "version": "2.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "storybook-zeplin",
-            "version": "1.7.13",
+            "version": "2.0.0",
             "license": "MIT",
             "dependencies": {
                 "@zeplin/sdk": "^1.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "storybook-zeplin",
-    "version": "1.7.3",
+    "version": "1.7.13",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "storybook-zeplin",
-            "version": "1.7.3",
+            "version": "1.7.13",
             "license": "MIT",
             "dependencies": {
                 "@zeplin/sdk": "^1.9.0",
-                "@zeplin/storybook-inspector": "^0.1.3",
+                "@zeplin/storybook-inspector": "^0.2.0",
                 "query-string": "^6.12.1",
                 "semver": "^7.3.5"
             },
@@ -1066,16 +1066,18 @@
             }
         },
         "node_modules/@zeplin/storybook-inspector": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/@zeplin/storybook-inspector/-/storybook-inspector-0.1.3.tgz",
-            "integrity": "sha512-fKsABLA2QigyjP2rwAmkWg83d66ETf5chLfCTqnhcmb7x/EGdLJB8hug0nan/Ti2gDOo2xDEGhXKp5+t7DMdkQ==",
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@zeplin/storybook-inspector/-/storybook-inspector-0.2.0.tgz",
+            "integrity": "sha512-0evrqTrtKvDORceP1K5MQHcXHJIhrNVnDTlX7BssHHbpJ7lgh1EyjxtAzSRoASfo4D2P02MBdp/h0/gXzf37hQ==",
             "dependencies": {
                 "lit-html": "^2.0.0-rc.3",
-                "prettier": "^2.4.1",
                 "query-string": "^7.0.1",
-                "react": "^16.14.0",
-                "react-element-to-jsx-string": "^14.3.2",
-                "vue": "^2.6.14"
+                "react-element-to-jsx-string": "^15.0.0"
+            },
+            "peerDependencies": {
+                "prettier": "^2.4.1",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+                "vue": "^2.6.14 || ^3.0.0"
             }
         },
         "node_modules/@zeplin/storybook-inspector/node_modules/query-string": {
@@ -1095,17 +1097,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/@zeplin/storybook-inspector/node_modules/react": {
-            "version": "16.14.0",
-            "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-            "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+        "node_modules/@zeplin/storybook-inspector/node_modules/react-element-to-jsx-string": {
+            "version": "15.0.0",
+            "resolved": "https://registry.npmjs.org/react-element-to-jsx-string/-/react-element-to-jsx-string-15.0.0.tgz",
+            "integrity": "sha512-UDg4lXB6BzlobN60P8fHWVPX3Kyw8ORrTeBtClmIlGdkOOE+GYQSFvmEU5iLLpwp/6v42DINwNcwOhOLfQ//FQ==",
             "dependencies": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2"
+                "@base2/pretty-print-object": "1.0.1",
+                "is-plain-object": "5.0.0",
+                "react-is": "18.1.0"
             },
-            "engines": {
-                "node": ">=0.10.0"
+            "peerDependencies": {
+                "react": "^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0",
+                "react-dom": "^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0"
             }
         },
         "node_modules/acorn": {
@@ -2186,6 +2189,7 @@
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
             "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+            "peer": true,
             "bin": {
                 "prettier": "bin-prettier.js"
             },
@@ -2200,16 +2204,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.6.0"
-            }
-        },
-        "node_modules/prop-types": {
-            "version": "15.7.2",
-            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-            "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-            "dependencies": {
-                "loose-envify": "^1.4.0",
-                "object-assign": "^4.1.1",
-                "react-is": "^16.8.1"
             }
         },
         "node_modules/punycode": {
@@ -2287,29 +2281,10 @@
                 "react": "17.0.2"
             }
         },
-        "node_modules/react-element-to-jsx-string": {
-            "version": "14.3.4",
-            "resolved": "https://registry.npmjs.org/react-element-to-jsx-string/-/react-element-to-jsx-string-14.3.4.tgz",
-            "integrity": "sha512-t4ZwvV6vwNxzujDQ+37bspnLwA4JlgUPWhLjBJWsNIDceAf6ZKUTCjdm08cN6WeZ5pTMKiCJkmAYnpmR4Bm+dg==",
-            "dependencies": {
-                "@base2/pretty-print-object": "1.0.1",
-                "is-plain-object": "5.0.0",
-                "react-is": "17.0.2"
-            },
-            "peerDependencies": {
-                "react": "^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1",
-                "react-dom": "^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1"
-            }
-        },
-        "node_modules/react-element-to-jsx-string/node_modules/react-is": {
-            "version": "17.0.2",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-        },
         "node_modules/react-is": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+            "version": "18.1.0",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
+            "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg=="
         },
         "node_modules/regenerator-runtime": {
             "version": "0.13.9",
@@ -2569,7 +2544,8 @@
         "node_modules/vue": {
             "version": "2.6.14",
             "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
-            "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
+            "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==",
+            "peer": true
         },
         "node_modules/watchpack": {
             "version": "2.4.0",
@@ -3512,16 +3488,13 @@
             }
         },
         "@zeplin/storybook-inspector": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/@zeplin/storybook-inspector/-/storybook-inspector-0.1.3.tgz",
-            "integrity": "sha512-fKsABLA2QigyjP2rwAmkWg83d66ETf5chLfCTqnhcmb7x/EGdLJB8hug0nan/Ti2gDOo2xDEGhXKp5+t7DMdkQ==",
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@zeplin/storybook-inspector/-/storybook-inspector-0.2.0.tgz",
+            "integrity": "sha512-0evrqTrtKvDORceP1K5MQHcXHJIhrNVnDTlX7BssHHbpJ7lgh1EyjxtAzSRoASfo4D2P02MBdp/h0/gXzf37hQ==",
             "requires": {
                 "lit-html": "^2.0.0-rc.3",
-                "prettier": "^2.4.1",
                 "query-string": "^7.0.1",
-                "react": "^16.14.0",
-                "react-element-to-jsx-string": "^14.3.2",
-                "vue": "^2.6.14"
+                "react-element-to-jsx-string": "^15.0.0"
             },
             "dependencies": {
                 "query-string": {
@@ -3535,14 +3508,14 @@
                         "strict-uri-encode": "^2.0.0"
                     }
                 },
-                "react": {
-                    "version": "16.14.0",
-                    "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-                    "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+                "react-element-to-jsx-string": {
+                    "version": "15.0.0",
+                    "resolved": "https://registry.npmjs.org/react-element-to-jsx-string/-/react-element-to-jsx-string-15.0.0.tgz",
+                    "integrity": "sha512-UDg4lXB6BzlobN60P8fHWVPX3Kyw8ORrTeBtClmIlGdkOOE+GYQSFvmEU5iLLpwp/6v42DINwNcwOhOLfQ//FQ==",
                     "requires": {
-                        "loose-envify": "^1.1.0",
-                        "object-assign": "^4.1.1",
-                        "prop-types": "^15.6.2"
+                        "@base2/pretty-print-object": "1.0.1",
+                        "is-plain-object": "5.0.0",
+                        "react-is": "18.1.0"
                     }
                 }
             }
@@ -4364,23 +4337,14 @@
         "prettier": {
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-            "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg=="
+            "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+            "peer": true
         },
         "process": {
             "version": "0.11.10",
             "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
             "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
             "dev": true
-        },
-        "prop-types": {
-            "version": "15.7.2",
-            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-            "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-            "requires": {
-                "loose-envify": "^1.4.0",
-                "object-assign": "^4.1.1",
-                "react-is": "^16.8.1"
-            }
         },
         "punycode": {
             "version": "2.1.1",
@@ -4436,27 +4400,10 @@
                 "scheduler": "^0.20.2"
             }
         },
-        "react-element-to-jsx-string": {
-            "version": "14.3.4",
-            "resolved": "https://registry.npmjs.org/react-element-to-jsx-string/-/react-element-to-jsx-string-14.3.4.tgz",
-            "integrity": "sha512-t4ZwvV6vwNxzujDQ+37bspnLwA4JlgUPWhLjBJWsNIDceAf6ZKUTCjdm08cN6WeZ5pTMKiCJkmAYnpmR4Bm+dg==",
-            "requires": {
-                "@base2/pretty-print-object": "1.0.1",
-                "is-plain-object": "5.0.0",
-                "react-is": "17.0.2"
-            },
-            "dependencies": {
-                "react-is": {
-                    "version": "17.0.2",
-                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-                    "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-                }
-            }
-        },
         "react-is": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+            "version": "18.1.0",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
+            "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg=="
         },
         "regenerator-runtime": {
             "version": "0.13.9",
@@ -4644,7 +4591,8 @@
         "vue": {
             "version": "2.6.14",
             "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
-            "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
+            "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==",
+            "peer": true
         },
         "watchpack": {
             "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "storybook-zeplin",
-    "version": "1.7.3",
+    "version": "1.7.13",
     "description": "Zeplin addon for Storybook",
     "main": "dist/index.js",
     "keywords": [
@@ -41,7 +41,7 @@
     },
     "dependencies": {
         "@zeplin/sdk": "^1.9.0",
-        "@zeplin/storybook-inspector": "^0.1.3",
+        "@zeplin/storybook-inspector": "^0.2.0",
         "query-string": "^6.12.1",
         "semver": "^7.3.5"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "storybook-zeplin",
-    "version": "1.7.13",
+    "version": "2.0.0",
     "description": "Zeplin addon for Storybook",
     "main": "dist/index.js",
     "keywords": [


### PR DESCRIPTION
Fixes #74

Upgrading @zeplin/storybook-inspector to 0.2.0 to avoid Vue issues until Zeplin's Storybook integration is separated from this addon. Check https://github.com/zeplin/storybook-inspector/pull/14 for more details. The changes will be published as a major upgrade as it could be a breaking change for some users. 