### PR TITLE
fix: zeplinLink not being found in the initial load of story

### DIFF
--- a/src/components/hooks/useLinks.ts
+++ b/src/components/hooks/useLinks.ts
@@ -84,6 +84,6 @@ export const useLinks = (zeplinLink: unknown): State => {
                 setState({ links: [{ link: zeplinLink, name: "Component" }], error: null, linksLoading: false });
             }
         }
-    }, [storyId]);
+    }, [storyId, zeplinLink]);
     return state;
 }


### PR DESCRIPTION
There is an issue in the initial load that zeplinLink is not found by the addon, until another story is being chosen and returning back to the first story again. This is caused by the effect does not have `zeplinLink` as a dependency.