### PR TITLE
Remove deprecate key from render function

### DIFF
--- a/src/register.tsx
+++ b/src/register.tsx
@@ -17,11 +17,11 @@ import { messenger } from "./utils/messenger";
 import { MainPanel } from "./components/MainPanel";
 
 addons.register(ADDON_ID, async api => {
-    const render = ({ active, key }) => {
+    const render = ({ active }) => {
         const zeplinLink = useParameter(PARAM_KEY, null);
 
         return (
-            <AddonPanel active={active} key={key}>
+            <AddonPanel active={active}>
                 <MainPanel zeplinLink={zeplinLink} />
             </AddonPanel>
         );


### PR DESCRIPTION
Key in the addon render function is deprecated.


See: https://github.com/storybookjs/storybook/pull/23792